### PR TITLE
TACT-126 fix task input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 *.tsbuildinfo
 next-env.d.ts
+
+.idea

--- a/components/shared/TaskCreator/view.tsx
+++ b/components/shared/TaskCreator/view.tsx
@@ -64,7 +64,7 @@ export const TaskCreatorView = observer(function TaskCreator(
         w='auto'
         {...props.wrapperProps}
       >
-        <InputGroup size='md' ref={ref} variant='unstyled'>
+        <InputGroup size='md' ref={ref} variant='unstyled' alignItems='center'>
           <TaskQuickEditorInput
             placeholder='+Add task'
             flex={1}


### PR DESCRIPTION
**Describe the issue**

[TACT-126](https://linear.app/octolab/issue/TACT-126/quick-editor-looks-weird-if-it-has-a-tag)

**Describe the pull request**

Add vertical align to `<InputGroup />`. There was problem with "tags" height. `<InputGroup />` is flex item, therefore input's height is changed and content jumps to up.

Also I added the `.idea` dir to `.gitignore`.