### PR TITLE
TACT-131 close other suggestions menu on open main menu

### DIFF
--- a/components/shared/TaskQuickEditor/store.ts
+++ b/components/shared/TaskQuickEditor/store.ts
@@ -210,6 +210,9 @@ export class TaskQuickEditorStore {
   openMenu = () => {
     this.isInputFocused = true;
     this.isMenuOpen = true;
+
+    this.suggestionsMenu.close();
+    this.suggestionsMenu.closeForMode();
   };
 
   closeMenu = () => {


### PR DESCRIPTION
**Describe the issue**

[TACT-131](https://linear.app/octolab/issue/TACT-131/overlay-windows)

**Describe the pull request**

Call methods for close all suggestions menu in the open main method.

Also there was same problem for all suggestions menu (like as priority, goals, etc).
