### PR TITLE
TACT-141 fix zIndex for main context menu

### DIFF
--- a/components/shared/TaskCreator/view.tsx
+++ b/components/shared/TaskCreator/view.tsx
@@ -71,7 +71,7 @@ export const TaskCreatorView = observer(function TaskCreator(
             pt={1}
             pb={1}
           />
-          <InputRightAddon maxW='50%' minWidth={0} justifyContent='end'>
+          <InputRightAddon maxW='50%' minWidth={0} justifyContent='end' position='relative' zIndex='100'>
             <Fade in={store.isInputFocused} unmountOnExit>
               <HStack w='100%'>
                 <TaskQuickEditorTags


### PR DESCRIPTION
**Describe the issue**

[TACT-141](https://linear.app/octolab/issue/TACT-141/fix-z-index-in-the-main-context-menu)

**Describe the pull request**

I added zIndex for block with right content of the task creator.
