### PR TITLE
TACT-115 fix goal assigning

### DIFF
--- a/components/shared/TasksList/store.ts
+++ b/components/shared/TasksList/store.ts
@@ -1,5 +1,6 @@
 import { RootStore } from '../../../stores/RootStore';
 import { makeAutoObservable, reaction, runInAction, toJS } from 'mobx';
+import cloneDeep from 'lodash/cloneDeep';
 import { getProvider } from '../../../helpers/StoreProvider';
 import { NavigationDirections, TaskData, TaskStatus } from './types';
 import { TaskQuickEditorProps } from '../TaskQuickEditor/store';
@@ -333,7 +334,7 @@ export class TasksListStore {
 
   assignGoal = (taskIds: string[], goalId: string) => {
     taskIds.forEach((id) => {
-      this.items[id].goalId = goalId;
+      this.items[id] = {...cloneDeep(this.items[id]), goalId};
     });
 
     this.root.api.tasks.assignGoal({

--- a/components/shared/TasksList/store.ts
+++ b/components/shared/TasksList/store.ts
@@ -334,6 +334,8 @@ export class TasksListStore {
 
   assignGoal = (taskIds: string[], goalId: string) => {
     taskIds.forEach((id) => {
+      // TODO:debt find a way to avoid cloning
+      //  see https://linear.app/octolab/issue/TACT-115/sync-the-goal-field-after-a-quick-edit-of-a-task
       this.items[id] = {...cloneDeep(this.items[id]), goalId};
     });
 


### PR DESCRIPTION
**Describe the issue**

[TACT-115](https://linear.app/octolab/issue/TACT-115/sync-the-goal-field-after-a-quick-edit-of-a-task)

**Describe the pull request**

There is problem with the `task.goalId` reactivity. Changing of this field doesn't fire the update method [here](https://github.com/tact-app/web/blob/main/components/shared/TaskQuickEditor/store.ts#L657-L692).
As quick fix I change all task object and reactivity works.
