### PR TITLE
TACT-141 fix zIndex for main context menu again

### DIFF
--- a/components/shared/TaskCreator/view.tsx
+++ b/components/shared/TaskCreator/view.tsx
@@ -62,6 +62,7 @@ export const TaskCreatorView = observer(function TaskCreator(
         display='flex'
         minH={10}
         w='auto'
+        zIndex='100'
         {...props.wrapperProps}
       >
         <InputGroup size='md' ref={ref} variant='unstyled' alignItems='center'>

--- a/components/shared/TaskCreator/view.tsx
+++ b/components/shared/TaskCreator/view.tsx
@@ -72,7 +72,12 @@ export const TaskCreatorView = observer(function TaskCreator(
             pt={1}
             pb={1}
           />
-          <InputRightAddon maxW='50%' minWidth={0} justifyContent='end' position='relative' zIndex='100'>
+          <InputRightAddon
+            maxW='50%'
+            minWidth={0}
+            justifyContent='end'
+            position='relative'
+          >
             <Fade in={store.isInputFocused} unmountOnExit>
               <HStack w='100%'>
                 <TaskQuickEditorTags


### PR DESCRIPTION
**Describe the issue**

[TACT-141](https://linear.app/octolab/issue/TACT-141/fix-z-index-in-the-main-context-menu)

**Describe the pull request**

There is regression after `@chakra-ui/react` update. I added z-index for input wrapper. 
