### PR TITLE
TACT-130 add api method spaces.add

### DIFF
--- a/stores/RootStore/Resources/SpacesStore.ts
+++ b/stores/RootStore/Resources/SpacesStore.ts
@@ -27,6 +27,7 @@ export class SpacesStore {
 
   add(space: SpaceData) {
     this.list.push(space);
+    this.root.api.spaces.add(space);
 
     if (this.count === 2) {
       this.list.unshift({


### PR DESCRIPTION
**Describe the issue**

[TACT-130](https://linear.app/octolab/issue/TACT-130/duplicating-spaces-when-editing-a-title)

**Describe the pull request**

I can't reproduce bug, but I lose created spaces. It was easy. We haven't api method for save new space.
Anyway, after fixing the add space method I can't reproduce bug.
