### PR TITLE
TACT-144 fix space origin creation

### DIFF
--- a/components/pages/Spaces/store.ts
+++ b/components/pages/Spaces/store.ts
@@ -211,6 +211,7 @@ export class SpacesStore {
     space.children.push(getRandomOrigins(space.id, 1)[0]);
 
     this.root.resources.spaces.update(space);
+    this.menu.loadSpaces();
   };
 
   getInboxItems = async () => {


### PR DESCRIPTION
**Describe the issue**

[TACT-144](https://linear.app/octolab/issue/TACT-144/error-while-creating-a-new-origin)

**Describe the pull request**

When user add new origin to space there isn't this new origin in the menu state.
I added fire the `loadSpaces` method. This method recalculate the menu tree.
