### PR TITLE
tact-96: disable sorting by cmd+shift+{direction}

### DIFF
--- a/components/pages/Goals/modals/GoalCreationModal/store.ts
+++ b/components/pages/Goals/modals/GoalCreationModal/store.ts
@@ -48,7 +48,7 @@ export class GoalCreationModalStore {
   }
 
   keyMap = {
-    CREATE: ['meta+enter', 'meta+s', 'ctrl+enter', 'ctrl+s'],
+    CREATE: ['meta+enter', 'meta+s'],
     CANCEL: ['escape'],
   };
 

--- a/components/pages/Spaces/components/SpacesInbox/store.ts
+++ b/components/pages/Spaces/components/SpacesInbox/store.ts
@@ -24,11 +24,11 @@ export class SpacesInboxStore {
   }
 
   keyMap = {
-    UP: 'arrowup',
-    DOWN: 'arrowdown',
-    LEAVE_LEFT: 'arrowleft',
-    LEAVE_RIGHT: 'arrowright',
-    SELECT: ['arrowright', 'enter'],
+    UP: 'up',
+    DOWN: 'down',
+    LEAVE_LEFT: 'left',
+    LEAVE_RIGHT: 'right',
+    SELECT: ['right', 'enter'],
     UNSELECT: 'escape',
   };
 

--- a/components/pages/Spaces/components/SpacesMenu/store.ts
+++ b/components/pages/Spaces/components/SpacesMenu/store.ts
@@ -45,12 +45,12 @@ export class SpacesMenuStore {
   checkState: OriginCheckStateTree = {};
 
   keyMap = {
-    UP: ['j', 'arrowup'],
-    FORCE_UP: ['meta+j', 'meta+arrowup', 'ctrl+j', 'ctrl+arrowup'],
-    DOWN: ['k', 'arrowdown'],
-    FORCE_DOWN: ['meta+k', 'meta+arrowdown', 'ctrl+k', 'ctrl+arrowdown'],
-    COLLAPSE: 'arrowleft',
-    EXPAND: 'arrowright',
+    UP: ['j', 'up'],
+    FORCE_UP: ['meta+j', 'meta+up'],
+    DOWN: ['k', 'down'],
+    FORCE_DOWN: ['meta+k', 'meta+down'],
+    COLLAPSE: 'left',
+    EXPAND: 'right',
     LEAVE: ['escape'],
     SELECT: ['space', 'enter'],
   };

--- a/components/pages/Spaces/modals/SpaceCreationModal/view.tsx
+++ b/components/pages/Spaces/modals/SpaceCreationModal/view.tsx
@@ -29,7 +29,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash } from '@fortawesome/pro-regular-svg-icons';
 
 const keyMap = {
-  CREATE: ['meta+enter', 'meta+s', 'ctrl+enter', 'ctrl+s'],
+  CREATE: ['meta+enter', 'meta+s'],
   CANCEL: ['escape'],
 };
 

--- a/components/pages/Today/components/Calendar/ResizableBlocks/store/navigation.ts
+++ b/components/pages/Today/components/Calendar/ResizableBlocks/store/navigation.ts
@@ -9,10 +9,10 @@ export class ResizableBlocksNavigation {
   }
 
   keyMap = {
-    RIGHT: 'arrowright',
-    LEFT: 'arrowleft',
-    UP: 'arrowup',
-    DOWN: 'arrowdown',
+    RIGHT: 'right',
+    LEFT: 'left',
+    UP: 'up',
+    DOWN: 'down',
     TAB: 'tab',
     SHIFT_TAB: 'shift+tab',
     ESC: 'escape',

--- a/components/pages/Today/components/FocusConfiguration/store.ts
+++ b/components/pages/Today/components/FocusConfiguration/store.ts
@@ -35,7 +35,7 @@ export class FocusConfigurationStore {
 
   keyMap = {
     FOCUS_GOAL_SELECTION: 'shift+g',
-    BLUR: 'arrowright',
+    BLUR: 'right',
     NUMBER: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
     CLEAR: ['shift+backspace', 'shift+delete', 'shift+c'],
     SHOW_IMPORTANT: 'i',

--- a/components/pages/Today/components/FocusConfiguration/view.tsx
+++ b/components/pages/Today/components/FocusConfiguration/view.tsx
@@ -14,8 +14,7 @@ import {
 } from '@chakra-ui/react';
 import { GoalsSelectionStoreProvider } from '../../../../shared/GoalsSelection/store';
 import { GoalsSelectionView } from '../../../../shared/GoalsSelection/view';
-import { useHotkeysHandler } from '../../../../../helpers/useHotkeysHandler';
-import { useRef } from 'react';
+import { useRef, LegacyRef } from 'react';
 import { useListNavigation } from '../../../../../helpers/ListNavigation';
 
 export const FocusConfigurationView = observer(function FocusConfigurationView(
@@ -24,9 +23,7 @@ export const FocusConfigurationView = observer(function FocusConfigurationView(
   const ref = useRef(null);
   const store = useFocusConfigurationStore();
 
-  useHotkeysHandler(store.keyMap, store.hotkeyHandlers);
-
-  const hotkeysRef = useListNavigation(store.navigation);
+  const hotkeysRef = useListNavigation(store.navigation, store.keyMap, store.hotkeyHandlers);
 
   useOutsideClick({
     ref,
@@ -62,7 +59,7 @@ export const FocusConfigurationView = observer(function FocusConfigurationView(
           Press ⇧ C to clear
         </Text>
         <Box
-          ref={hotkeysRef}
+          ref={hotkeysRef as LegacyRef<HTMLDivElement>}
           p={2}
           pl={1}
           borderRadius='md'

--- a/components/pages/Today/store.ts
+++ b/components/pages/Today/store.ts
@@ -91,8 +91,8 @@ export class TodayStore {
     FOCUS_INPUT: 'n',
     FOCUS_MODE: 'f',
     SILENT_FOCUS_MODE: 'shift+f',
-    SWITCH_LIST_TODAY: ['t', 'alt+shift+arrowup'],
-    SWITCH_LIST_WEEK: ['w', 'alt+shift+arrowdown'],
+    SWITCH_LIST_TODAY: ['t', 'alt+shift+up'],
+    SWITCH_LIST_WEEK: ['w', 'alt+shift+down'],
     MOVE_TASK: ['alt+s'],
     TOGGLE_CALENDAR: 'c',
   };

--- a/components/shared/DraggableList/store.ts
+++ b/components/shared/DraggableList/store.ts
@@ -96,12 +96,12 @@ export class DraggableListStore {
     FORCE_DOWN: ['meta+k', 'meta+down', 'l'],
     EDIT: 'space',
     MOVE_UP: [
-      'meta+shift+j',
-      'meta+shift+up'
+      'shift+ctrl+j',
+      'shift+ctrl+up'
     ],
     MOVE_DOWN: [
-      'meta+shift+k',
-      'meta+shift+down',
+      'shift+ctrl+k',
+      'shift+ctrl+down',
     ],
     SELECT_UP: ['shift+j', 'shift+up'],
     SELECT_DOWN: ['shift+k', 'shift+down'],

--- a/components/shared/DraggableList/store.ts
+++ b/components/shared/DraggableList/store.ts
@@ -90,32 +90,26 @@ export class DraggableListStore {
   }
 
   keymap = {
-    UP: ['j', 'arrowup'],
-    DOWN: ['k', 'arrowdown'],
-    FORCE_UP: ['meta+j', 'meta+arrowup', 'ctrl+j', 'ctrl+arrowup', 'h'],
-    FORCE_DOWN: ['meta+k', 'meta+arrowdown', 'ctrl+k', 'ctrl+arrowdown', 'l'],
+    UP: ['j', 'up'],
+    DOWN: ['k', 'down'],
+    FORCE_UP: ['meta+j', 'meta+up', 'h'],
+    FORCE_DOWN: ['meta+k', 'meta+down', 'l'],
     EDIT: 'space',
     MOVE_UP: [
       'meta+shift+j',
-      'meta+shift+arrowup',
-      'ctrl+shift+j',
-      'ctrl+shift+arrowup',
+      'meta+shift+up'
     ],
     MOVE_DOWN: [
       'meta+shift+k',
-      'meta+shift+arrowdown',
-      'ctrl+shift+k',
-      'ctrl+shift+arrowdown',
+      'meta+shift+down',
     ],
-    SELECT_UP: ['shift+j', 'shift+arrowup'],
-    SELECT_DOWN: ['shift+k', 'shift+arrowdown'],
-    SELECT_ALL: ['meta+a', 'ctrl+a'],
+    SELECT_UP: ['shift+j', 'shift+up'],
+    SELECT_DOWN: ['shift+k', 'shift+down'],
+    SELECT_ALL: ['meta+a'],
     ESC: 'escape',
     FORCE_DELETE: [
       'meta+backspace',
-      'meta+delete',
-      'ctrl+backspace',
-      'ctrl+delete',
+      'meta+delete'
     ],
     DELETE: ['del', 'backspace'],
   };

--- a/components/shared/HotkeyBlock/index.tsx
+++ b/components/shared/HotkeyBlock/index.tsx
@@ -9,10 +9,10 @@ const dict = {
   alt: '⌥',
   options: '⌥',
   ctrl: '⌃',
-  arrowup: '↑',
-  arrowdown: '↓',
-  arrowleft: '←',
-  arrowright: '→',
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
 };
 
 export const HotkeyBlock = observer(function HotkeyBlock({

--- a/components/shared/TaskQuickEditor/store.ts
+++ b/components/shared/TaskQuickEditor/store.ts
@@ -590,7 +590,7 @@ export class TaskQuickEditorStore {
         this.callbacks.onNavigate?.(NavigationDirections.ENTER);
       }
 
-      this.saveTask(e.shiftKey, e.metaKey || e.ctrlKey);
+      this.saveTask(e.shiftKey, e.metaKey);
     } else if (mode) {
       e.stopPropagation();
       this.enterMode(mode, e);

--- a/components/shared/TasksList/components/TaskItem/store.ts
+++ b/components/shared/TasksList/components/TaskItem/store.ts
@@ -69,7 +69,7 @@ export class TaskItemStore {
   }
 
   handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Alt' && !e.metaKey && !e.shiftKey && !e.ctrlKey) {
+    if (e.key === 'Alt' && !e.metaKey && !e.shiftKey) {
       this.isAltPressed = true;
     } else if (this.isAltPressed) {
       this.isAltPressed = false;
@@ -151,7 +151,7 @@ export class TaskItemStore {
     let newStatus;
 
     if (this.task.status === TaskStatus.TODO) {
-      if (nativeEvent.metaKey || nativeEvent.ctrlKey) {
+      if (nativeEvent.metaKey) {
         newStatus = TaskStatus.WONT_DO;
 
         if (nativeEvent.shiftKey) {
@@ -162,7 +162,7 @@ export class TaskItemStore {
         newStatus = TaskStatus.DONE;
       }
     } else {
-      if (nativeEvent.metaKey || nativeEvent.ctrlKey) {
+      if (nativeEvent.metaKey) {
         if (this.task.status === TaskStatus.DONE) {
           newStatus = TaskStatus.WONT_DO;
 

--- a/components/shared/TasksList/components/TaskItemMenu/index.tsx
+++ b/components/shared/TasksList/components/TaskItemMenu/index.tsx
@@ -88,7 +88,7 @@ const multiTaskItems = (store: TaskItemStore) => [
       store.parent.deleteWithVerify(store.parent.draggableList.focused),
     title: 'Delete tasks',
     icon: faXmark,
-    hotkey: ['backspace', 'meta+backspace', 'ctrl+backspace'],
+    hotkey: ['backspace', 'meta+backspace'],
     command: '⌫ / ⌘⌫',
   },
 ];
@@ -179,7 +179,7 @@ const singleTaskItems = (store: TaskItemStore) => [
     onClick: () => store.parent.deleteWithVerify([store.task.id]),
     title: 'Delete task',
     icon: faXmark,
-    hotkey: ['backspace', 'meta+backspace', 'ctrl+backspace'],
+    hotkey: ['backspace', 'meta+backspace'],
     command: '⌫ / ⌘⌫',
   },
 ];

--- a/components/shared/TasksList/modals/TaskGoalAssignModal/view.tsx
+++ b/components/shared/TasksList/modals/TaskGoalAssignModal/view.tsx
@@ -9,7 +9,6 @@ import {
 } from '@chakra-ui/modal';
 import { Button, Text } from '@chakra-ui/react';
 import { useTaskGoalAssignModalStore } from './store';
-import { useHotkeysHandler } from '../../../../../helpers/useHotkeysHandler';
 import React from 'react';
 import { GoalsSelection } from '../../../GoalsSelection';
 import { useListNavigation } from '../../../../../helpers/ListNavigation';
@@ -18,17 +17,13 @@ export const TaskGoalAssignModalView = observer(
   function TaskGoalAssignModalView() {
     const store = useTaskGoalAssignModalStore();
 
-    const ref = useHotkeysHandler(store.keyMap, store.hotkeyHandlers);
-    const hotkeysRef = useListNavigation(store.navigation);
+   const hotkeysRef = useListNavigation(store.navigation, store.keyMap, store.hotkeyHandlers);
 
     return (
       <Modal isCentered isOpen={true} onClose={store.callbacks.onClose}>
         <ModalOverlay />
         <ModalContent
-          ref={(el) => {
-            ref(el);
-            hotkeysRef(el);
-          }}
+          ref={hotkeysRef}
           onFocus={store.navigation.handleFocus}
         >
           <ModalHeader>My goals</ModalHeader>

--- a/components/shared/TasksList/modals/TaskWontDoModal/store.ts
+++ b/components/shared/TasksList/modals/TaskWontDoModal/store.ts
@@ -78,7 +78,7 @@ export class TaskWontDoModalStore {
         e.stopPropagation();
       }
     } else if (e.key === 'Enter') {
-      if (!(e.metaKey || e.ctrlKey)) {
+      if (!(e.metaKey)) {
         e.stopPropagation();
       }
     } else {

--- a/components/shared/TasksList/store.ts
+++ b/components/shared/TasksList/store.ts
@@ -68,8 +68,8 @@ export class TasksListStore {
     FORCE_WONT_DO: ['alt+w'],
     EDIT: 'space',
     OPEN_AND_EDIT: 'enter',
-    FOCUS_LEAVE_LEFT: 'arrowleft',
-    FOCUS_LEAVE_RIGHT: 'arrowright',
+    FOCUS_LEAVE_LEFT: 'left',
+    FOCUS_LEAVE_RIGHT: 'right',
     OPEN: 'enter',
   };
 

--- a/helpers/ListNavigation.ts
+++ b/helpers/ListNavigation.ts
@@ -1,5 +1,8 @@
 import { makeAutoObservable } from 'mobx';
 import { useHotkeysHandler } from './useHotkeysHandler';
+import {
+  HotkeysEvent,
+} from 'react-hotkeys-hook/src/types';
 import { useEffect } from 'react';
 
 const numbers = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
@@ -12,14 +15,17 @@ export type NavigationCallbacks = {
 
 const defaultCallbacks: NavigationCallbacks = {};
 
-export const useListNavigation = (listNavigation: ListNavigation) => {
+export const useListNavigation = (listNavigation: ListNavigation,
+  storeKeyMap?: Record<string, string[] | string>,
+  storeHotkeyHandlers?: Record<string, (event: KeyboardEvent, handler: HotkeysEvent) => void
+  >) => {
   useEffect(() => {
     listNavigation.init();
   }, [listNavigation]);
 
   return useHotkeysHandler(
-    listNavigation.keyMap,
-    listNavigation.hotkeyHandlers,
+    { ...listNavigation.keyMap, ...(storeKeyMap || {}) },
+    { ...listNavigation.hotkeyHandlers, ...(storeHotkeyHandlers || {}) },
     { enabled: listNavigation.isEnabled }
   );
 };

--- a/helpers/ListNavigation.ts
+++ b/helpers/ListNavigation.ts
@@ -34,12 +34,12 @@ export class ListNavigation {
   focusedIndex: number | null = 0;
 
   keyMap = {
-    UP: ['arrowup', 'j'],
-    DOWN: ['arrowdown', 'k'],
+    UP: ['up', 'j'],
+    DOWN: ['down', 'k'],
     ENTER: ['enter'],
-    FORCE_ENTER: ['meta+enter', 'ctrl+enter'],
-    FIRST: ['meta+arrowup', 'meta+j', 'ctrl+arrowup', 'ctrl+j', 'h'],
-    LAST: ['meta+arrowdown', 'meta+k', 'ctrl+arrowdown', 'ctrl+k', 'l'],
+    FORCE_ENTER: ['meta+enter'],
+    FIRST: ['meta+up', 'meta+j', 'h'],
+    LAST: ['meta+down', 'meta+k', 'l'],
     NUMBERS: numbers,
   };
 

--- a/helpers/useHotkeysHandler.ts
+++ b/helpers/useHotkeysHandler.ts
@@ -13,15 +13,11 @@ const normalizeKey = (key: string) => {
 };
 
 const getNormalizedKeyFromEvent = (e: HotkeysEvent) => {
-  const { keys, mod, ctrl, meta, alt, shift } = e;
+  const { keys, mod, meta, alt, shift } = e;
   const items = [];
 
   if (mod) {
     items.push('mod');
-  }
-
-  if (ctrl) {
-    items.push('ctrl');
   }
 
   if (meta) {
@@ -92,9 +88,10 @@ export const useHotkeysHandler = (
 
   const handleHotkey = useCallback(
     (event, hotkeysEvent) => {
+      const {metaKey, shiftKey, key} = event
+      if(shiftKey && metaKey && (key === 'ArrowDown' || key === 'ArrowUp' )) return
       const matchedHandlerName =
         revertedKeymap[getNormalizedKeyFromEvent(hotkeysEvent)];
-
       if (matchedHandlerName) {
         matchedHandlerName.forEach((name) => {
           if (handlers[name]) {

--- a/helpers/useHotkeysHandler.ts
+++ b/helpers/useHotkeysHandler.ts
@@ -9,7 +9,7 @@ const normalizeKey = (key: string) => {
   const arr = key.split('+');
   const keyName = arr.pop();
 
-  return arr.sort().concat(keyName).join('+');
+  return arr.concat(keyName).join('+');
 };
 
 const getNormalizedKeyFromEvent = (e: HotkeysEvent) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
-        "react-hotkeys-hook": "github:tact-app/react-hotkeys-hook#types-fix",
+        "react-hotkeys-hook": "^4.3.2",
         "react-rnd": "^10.4.1",
         "tippy.js": "^6.3.7",
         "use-resize-observer": "^9.1.0",
@@ -6893,9 +6893,9 @@
       }
     },
     "node_modules/react-hotkeys-hook": {
-      "version": "4.0.4",
-      "resolved": "git+ssh://git@github.com/tact-app/react-hotkeys-hook.git#13cda71cf216d6c5c2c25cd518bcd6b5b8980caa",
-      "license": "MIT",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.3.2.tgz",
+      "integrity": "sha512-ZA/li3kBDHuRTtJIf7Td41UU87bPtnt9xV4r+PlEzpnFoYRDVspk3B+mlaX75zowyQygMVmoaWnM4B88lkyExQ==",
       "peerDependencies": {
         "react": ">=16.8.1",
         "react-dom": ">=16.8.1"
@@ -13088,8 +13088,9 @@
       }
     },
     "react-hotkeys-hook": {
-      "version": "git+ssh://git@github.com/tact-app/react-hotkeys-hook.git#13cda71cf216d6c5c2c25cd518bcd6b5b8980caa",
-      "from": "react-hotkeys-hook@github:tact-app/react-hotkeys-hook#types-fix",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.3.2.tgz",
+      "integrity": "sha512-ZA/li3kBDHuRTtJIf7Td41UU87bPtnt9xV4r+PlEzpnFoYRDVspk3B+mlaX75zowyQygMVmoaWnM4B88lkyExQ==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
-    "react-hotkeys-hook": "github:tact-app/react-hotkeys-hook#types-fix",
+    "react-hotkeys-hook": "^4.3.2",
     "react-rnd": "^10.4.1",
     "tippy.js": "^6.3.7",
     "use-resize-observer": "^9.1.0",

--- a/services/api/Database/entities/tasks.ts
+++ b/services/api/Database/entities/tasks.ts
@@ -165,7 +165,6 @@ const data = {
         destination?: number;
       }
     ) => {
-      console.log('swap', data);
 
       await updateList(db, data.fromListId, (list) => {
         list.taskIds = list.taskIds.filter((id) => !data.taskIds.includes(id));

--- a/stores/RootStore/Resources/SpacesStore.ts
+++ b/stores/RootStore/Resources/SpacesStore.ts
@@ -94,7 +94,6 @@ export class SpacesStore {
 
     runInAction(() => {
       this.list = spaces;
-      console.log('spaces inited', this.count);
     });
   };
 }


### PR DESCRIPTION
updated react-hotkeys-hook to 4.3.2;
updated all key maps and removed Ctrl conditions and hotkeys with Ctrl;
blocked sorting by Cmd+Shift+{direction};
removed console.logs.
