### PR TITLE
TACT-149: Going to the past and changing the mesh

### DIFF
--- a/components/pages/Today/components/Calendar/store.ts
+++ b/components/pages/Today/components/Calendar/store.ts
@@ -112,10 +112,7 @@ export class CalendarStore {
   };
 
   setResolution = (count: number) => {
-    if (this.currentLeftDay % count !== 0) {
-      this.currentLeftDay = Math.floor(this.currentLeftDay / count) * count;
-    }
-
+    this.currentLeftDay = 0;
     this.daysCount = count;
   };
 


### PR DESCRIPTION
**Describe the issue**

[TACT-149](https://linear.app/octolab/issue/TACT-149/going-to-the-past-and-changing-the-mesh)

**Describe the pull request**

Removed the unnecessary appointment of the current left day. The leftmost day should always be reassigned to 0.
Must be merged with https://github.com/tact-app/web/pull/279
