### PR TITLE
TACT-161 default return true in the handleNavigation

### DIFF
--- a/components/shared/TasksList/store.ts
+++ b/components/shared/TasksList/store.ts
@@ -265,6 +265,8 @@ export class TasksListStore {
 
       return true;
     }
+
+    return true;
   };
 
   handleTaskItemNavigation = (direction: NavigationDirections) => {


### PR DESCRIPTION
**Describe the issue**

[TACT-161](https://linear.app/octolab/issue/TACT-161/loss-of-focus-does-not-work-when-pressing-esc)

**Describe the pull request**

When user key down "Esc" it checks handle `handleNavigation` before losing focus actions.

But `handleNavigation` check only "up", "down" and "left" keys, by default handler returns undefined.

I added return `true` by default.
