### PR TITLE
TACT-139: Long title task are not supported and block scrolling in the preview of the task

### DIFF
--- a/components/shared/TaskQuickEditor/store.ts
+++ b/components/shared/TaskQuickEditor/store.ts
@@ -101,6 +101,7 @@ export class TaskQuickEditorStore {
 
   modeStartPos = 0;
   modeEndPos = 0;
+  maxDefaultModeTextLength = 50;
   activeModeType: Modes = Modes.DEFAULT;
   focusedMode: Modes | null = null;
   inputData: SpacesInboxItemData | null = null;
@@ -126,7 +127,11 @@ export class TaskQuickEditorStore {
   }
 
   get maxLength() {
-    if (this.activeMode?.maxLength) {
+    if (!this.activeMode) {
+      return this.maxDefaultModeTextLength;
+    }
+
+    if (this.activeMode.maxLength) {
       return (
         this.value.length +
         this.activeMode.maxLength -


### PR DESCRIPTION
**Describe the issue**

[TACT-139](https://linear.app/octolab/issue/TACT-139/long-title-task-are-not-supported-and-block-scrolling-in-the-preview)

**Describe the pull request**

Limited the length of the task title
