### PR TITLE
TACT-107: Phantom command menu

### DIFF
--- a/components/shared/Editor/components/EditorCreateMenu/store.ts
+++ b/components/shared/Editor/components/EditorCreateMenu/store.ts
@@ -39,11 +39,6 @@ export class EditorCreateMenuStore {
       return true;
     }
 
-    if (event.key === 'Esc') {
-      this.onClose?.();
-      return true;
-    }
-
     return false;
   };
 

--- a/components/shared/Editor/store.ts
+++ b/components/shared/Editor/store.ts
@@ -65,7 +65,14 @@ class EditorStore {
       Extension.create({
         addKeyboardShortcuts() {
           return {
-            Escape: ({ editor }) => editor.commands.blur(),
+            Escape: ({ editor }) => {
+              if (converterMenu.isOpen) {
+                converterMenu.handleClose();
+                return false;
+              }
+
+              return editor.commands.blur();
+            },
             'Cmd-s': () => {
               handleSave?.();
               return true;


### PR DESCRIPTION
**Describe the issue**

[TACT-107](https://linear.app/octolab/issue/TACT-107/phantom-command-menu)

**Describe the pull request**

Implemented closing the context menu in the editor by pressing the ESC key.
